### PR TITLE
Little screenshot embed fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ It works by exploiting [SteamAchievementManager](https://github.com/gibbed/Steam
   To have your desired windows always on top use [AlwaysOnTop](https://github.com/daniel-barbu/AlwaysOnTop).
 
 ### Screenshot
-![img/screenshot.png did not load correctly](/img/screenshot.png)
+![https://raw.githubusercontent.com/daniel-barbu/daniGameIdler/master/img/screenshot.png](/img/screenshot.png)


### PR DESCRIPTION
I’ve been checking some of the most recent steam related project on GitHub and stumbled onto yours. 
While I’m not interested into using it, nor having the ability to help its development, I just wanted to propose a little fix for the README.md.
I have no idea if precising the emplacement of the local file might work when creating a GitHub Page of this repo, but it surely doesn’t work when consulting the repo directly. I’ve switched it instead to the local raw link of that same screenshot.
Oh, and I assure you that I ain’t a bot.